### PR TITLE
Load font on current protocol

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -1,7 +1,7 @@
 <html>
 <head>
 	<title>Hello world!</title>
-	<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+	<link href='//fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
 	<style>
 	body {
 		background-color: white;


### PR DESCRIPTION
uses the current protocol http/https to load the external assets

this will break if loading over `file://` protocol (unlikely). [alternate solution](https://github.com/docker/dockercloud-hello-world/issues/1) is to always use https.

Fixes #2
